### PR TITLE
Make transformer simpler

### DIFF
--- a/src/infra/repositories/company/transform.js
+++ b/src/infra/repositories/company/transform.js
@@ -1,28 +1,6 @@
 const { Company } = require('src/domain/company')
 
-const toEntity = ({
-  id,
-  name,
-  address,
-  contact,
-  tin,
-  sss,
-  philhealth,
-  isDeleted,
-  createdBy,
-  updatedBy
-}) => Company({
-  id,
-  name,
-  address,
-  contact,
-  tin,
-  sss,
-  philhealth,
-  isDeleted,
-  createdBy,
-  updatedBy
-})
+const toEntity = Company
 
 module.exports = {
   toEntity

--- a/src/infra/repositories/user/transform.js
+++ b/src/infra/repositories/user/transform.js
@@ -1,28 +1,6 @@
 const { User } = require('src/domain/user')
 
-const toEntity = ({
-  id,
-  firstName,
-  lastName,
-  middleName,
-  email,
-  password,
-  roleId,
-  isDeleted,
-  createdBy,
-  updatedBy
-}) => User({
-  id,
-  firstName,
-  lastName,
-  middleName,
-  email,
-  password,
-  roleId,
-  isDeleted,
-  createdBy,
-  updatedBy
-})
+const toEntity = User
 
 module.exports = {
   toEntity


### PR DESCRIPTION
Change implementation for transformer. Instead of passing every property we just pass the response value from `sequelize` to the `domain` where it matches the fields.