### PR TITLE
String default value for User model

### DIFF
--- a/src/infra/database/models/user.js
+++ b/src/infra/database/models/user.js
@@ -35,7 +35,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     verificationCode: {
       type: DataTypes.STRING,
-      defaultValue: 0
+      defaultValue: ''
     },
     isVerified: {
       type: DataTypes.INTEGER,


### PR DESCRIPTION
Numeric '0' as a default caused problems with MySQL, like: TypeError: [tcomb] Invalid value 0 supplied to Struct