### PR TITLE
Config not needed seqeulizeV5

### DIFF
--- a/src/infra/sequelize/index.js
+++ b/src/infra/sequelize/index.js
@@ -7,7 +7,7 @@ module.exports = ({ config, basePath }) => {
     config.db.url,
     // we have to remove the depraction warning
     // https://github.com/sequelize/sequelize/issues/8417
-    { ...config.db, operatorsAliases: false }
+    { ...config.db }
 
   )
 


### PR DESCRIPTION
As [sequelize](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md) migration to v5 guide. 